### PR TITLE
CI: Add arm64 build for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        rid: [any, linux-arm, linux-arm64, linux-x64, osx-x64, win-x64]
+        rid: [any, linux-arm, linux-arm64, linux-x64, osx-x64, osx-arm64, win-x64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        rid: [any, linux-arm, linux-arm64, linux-x64, osx-x64, win-x64]
+        rid: [any, linux-arm, linux-arm64, linux-x64, osx-x64, osx-arm64, win-x64]
         build_configuration: [Release]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
.NET 6.0 supports build for Apple Silicon Macs by just passing `-r osx-arm64`.

Tested on my [forked tag](https://github.com/hguandl/BililiveRecorder/releases/tag/v2.0.0-1). The built binaries work well on MacBook Pro (13-inch, M1, 2020).

Note: Apple has special security restrictions. We need to sign the binaries before we run. The commands are shown as followed. Perhaps we should add this to the documentation.

```shell
# Remove the quarantine attributes
$ xattr -cr . 
# Use ad-hoc sign
$ codesign -fs - --deep BililiveRecorder.Cli
```

[![asciicast](https://asciinema.org/a/4SepVOSkgCr9UNY5pqbpAgDVX.svg)](https://asciinema.org/a/4SepVOSkgCr9UNY5pqbpAgDVX?t=24)