### PR TITLE
CI: make `any` fully platform unspecific

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build CLI
         if: ${{ matrix.rid == 'any' }}
-        run: dotnet publish -c ${{ matrix.build_configuration }} -p:UseAppHost=false BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
+        run: dotnet publish -c ${{ matrix.build_configuration }} BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
       - name: Build CLI
         if: ${{ matrix.rid != 'any' }}
         run: dotnet publish -c ${{ matrix.build_configuration }} -r ${{ matrix.rid }} BililiveRecorder.Cli/BililiveRecorder.Cli.csproj

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build CLI
         if: ${{ matrix.rid == 'any' }}
-        run: dotnet publish -c ${{ matrix.build_configuration }} BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
+        run: dotnet publish -c ${{ matrix.build_configuration }} -p:UseAppHost=false BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
       - name: Build CLI
         if: ${{ matrix.rid != 'any' }}
         run: dotnet publish -c ${{ matrix.build_configuration }} -r ${{ matrix.rid }} BililiveRecorder.Cli/BililiveRecorder.Cli.csproj

--- a/BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
+++ b/BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
@@ -4,9 +4,11 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <StartupObject>BililiveRecorder.Cli.Program</StartupObject>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <RuntimeIdentifiers>win-x64;osx-x64;osx.10.11-x64;linux-arm64;linux-arm;linux-x64</RuntimeIdentifiers>
     <RuntimeIdentifier Condition=" '$(RuntimeIdentifier)' == 'any' "></RuntimeIdentifier>
+    <UseAppHost Condition=" '$(RuntimeIdentifier)' == '' and '$(Configuration)' != 'Debug' ">false</UseAppHost>
     <PublishDir Condition=" '$(RuntimeIdentifier)' == '' ">publish\any\$(Configuration)</PublishDir>
     <PublishDir Condition=" '$(RuntimeIdentifier)' != '' ">publish\$(RuntimeIdentifier)\$(Configuration)</PublishDir>
     <SelfContained Condition=" '$(RuntimeIdentifier)' == '' ">false</SelfContained>

--- a/BililiveRecorder.Web/BililiveRecorder.Web.csproj
+++ b/BililiveRecorder.Web/BililiveRecorder.Web.csproj
@@ -1,14 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <SelfContained Condition=" '$(RuntimeIdentifier)' == '' ">false</SelfContained>
     <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
   </PropertyGroup>
   
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.17.1" />
     <PackageReference Include="AutoMapper" Version="11.0.1" />


### PR DESCRIPTION
As https://docs.microsoft.com/en-us/dotnet/core/deploying/deploy-with-cli points out, dotnet >3.1 will produce a platform-specific executable by default unless set UseAppHost=false