### PR TITLE
feat: Split by Title (#441)

### DIFF
--- a/BililiveRecorder.Core/Config/CuttingMode.cs
+++ b/BililiveRecorder.Core/Config/CuttingMode.cs
@@ -1,6 +1,8 @@
+using System;
 namespace BililiveRecorder.Core.Config
 {
-    [Flags] public enum CuttingMode : int
+    [Flags]
+    public enum CuttingMode : int
     {
         /// <summary>
         /// 禁用

--- a/BililiveRecorder.Core/Config/CuttingMode.cs
+++ b/BililiveRecorder.Core/Config/CuttingMode.cs
@@ -1,18 +1,22 @@
 namespace BililiveRecorder.Core.Config
 {
-    public enum CuttingMode : int
+    [Flags] public enum CuttingMode : int
     {
         /// <summary>
         /// 禁用
         /// </summary>
-        Disabled,
+        Disabled = 0, // 0
         /// <summary>
         /// 根据时间切割
         /// </summary>
-        ByTime,
+        ByTime = 1 << 0, // 1
         /// <summary>
         /// 根据文件大小切割
         /// </summary>
-        BySize,
+        BySize = 1 << 1, // 2, 0b_0010
+        /// <summary>
+        /// 根据直播间标题切割
+        /// </summary>
+        ByTitle = 1 << 2, // 4, 0b_0100
     }
 }

--- a/BililiveRecorder.Core/Recording/StandardRecordTask.cs
+++ b/BililiveRecorder.Core/Recording/StandardRecordTask.cs
@@ -58,7 +58,7 @@ namespace BililiveRecorder.Core.Recording
 
             this.statsRule = new StatsRule();
             this.splitFileRule = new SplitRule();
-
+            
             this.statsRule.StatsUpdated += this.StatsRule_StatsUpdated;
 
             this.pipeline = builder
@@ -268,20 +268,19 @@ namespace BililiveRecorder.Core.Recording
                 };
             }
         }
-
         private void StatsRule_StatsUpdated(object? sender, RecordingStatsEventArgs e)
         {
-            switch (this.room.RoomConfig.CuttingMode)
-            {
-                case CuttingMode.ByTime:
-                    if (e.FileMaxTimestamp > this.room.RoomConfig.CuttingNumber * 60u * 1000u)
-                        this.splitFileRule.SetSplitBeforeFlag();
-                    break;
-                case CuttingMode.BySize:
-                    if ((e.CurrentFileSize + (e.OutputVideoBytes * 1.1) + e.OutputAudioBytes) / (1024d * 1024d) > this.room.RoomConfig.CuttingNumber)
-                        this.splitFileRule.SetSplitBeforeFlag();
-                    break;
-            }
+            var RoomCuttingMode = this.room.RoomConfig.CuttingMode;
+            bool byTime = RoomCuttingMode.HasFlag(CuttingMode.ByTime);
+            bool bySize = RoomCuttingMode.HasFlag(CuttingMode.BySize);
+            // bool byTitle = RoomCuttingMode.HasFlag(CuttingMode.ByTitle);
+            // uint? _CuttingNumberTime = this.room.RoomConfig.CuttingNumberTime ??  this.room.RoomConfig.CuttingNumber;
+            // uint? _CuttingNumberSize = this.room.RoomConfig.CuttingNumberSize ??  this.room.RoomConfig.CuttingNumber;
+
+            if (byTime && e.FileMaxTimestamp > this.room.RoomConfig.CuttingNumber * 60u * 1000u)
+                {this.splitFileRule.SetSplitBeforeFlag();}
+            else if (bySize && (e.CurrentFileSize + (e.OutputVideoBytes * 1.1) + e.OutputAudioBytes) / (1024d * 1024d) > this.room.RoomConfig.CuttingNumber)
+                {this.splitFileRule.SetSplitBeforeFlag();}
 
             this.OnRecordingStats(e);
         }

--- a/BililiveRecorder.Core/Room.cs
+++ b/BililiveRecorder.Core/Room.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BililiveRecorder.Core.Api;
 using BililiveRecorder.Core.Config.V3;
+using BililiveRecorder.Core.Config;
 using BililiveRecorder.Core.Danmaku;
 using BililiveRecorder.Core.Event;
 using BililiveRecorder.Core.Recording;
@@ -667,6 +668,11 @@ retry:
                     else
                     {
                         this.AutoRecordForThisSession = true;
+                    }
+                    break;
+                case nameof(this.Title):
+                    if (this.RoomConfig.CuttingMode.HasFlag(CuttingMode.ByTitle)){
+                        this.recordTask.SplitOutput();
                     }
                     break;
                 default:

--- a/BililiveRecorder.Core/Room.cs
+++ b/BililiveRecorder.Core/Room.cs
@@ -672,7 +672,8 @@ retry:
                     break;
                 case nameof(this.Title):
                     if (this.RoomConfig.CuttingMode.HasFlag(CuttingMode.ByTitle)){
-                        this.recordTask.SplitOutput();
+                        // this.recordTask.SplitOutput();
+                        this.SplitOutput();
                     }
                     break;
                 default:

--- a/BililiveRecorder.WPF/BililiveRecorder.WPF.csproj
+++ b/BililiveRecorder.WPF/BililiveRecorder.WPF.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Converters\ByteUnitsConverter.cs" />
     <Compile Include="Converters\ClipEnabledToBooleanConverter.cs" />
     <Compile Include="Converters\EnumToBooleanConverter.cs" />
+    <Compile Include="Converters\FlagsEnumToBooleanConverter.cs" />
     <Compile Include="Converters\IsNullToVisibilityConverter.cs" />
     <Compile Include="Converters\RatioToArrowIconConverter.cs" />
     <Compile Include="Converters\IsNaNToValueConverter.cs" />

--- a/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
+++ b/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
@@ -83,9 +83,8 @@
                                 <RadioButton GroupName="Splitting" Content="{l:Loc Settings_Splitting_RadioButton_ByTime}"
                                  IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
                         ConverterParameter={x:Static config:CuttingMode.ByTime}}" />
-                                <ToggleSwitch GroupName="Splitting" Name="CutByTitleToggleSwitch" Content="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"
-                                 IsChecked="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, 
-                        ConverterParameter={x:Static config:CuttingMode.ByTitle}}"/>
+                                <ui:ToggleSwitch IsOn="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, ConverterParameter={x:Static config:CuttingMode.ByTitle}}"
+                                         OnContent="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}" OffContent="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"/>
                             </StackPanel>
                         </local:SettingWithDefault>
                         <local:SettingWithDefault IsSettingNotUsingDefault="{Binding HasCuttingNumber}">

--- a/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
+++ b/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
@@ -83,6 +83,9 @@
                                 <RadioButton GroupName="Splitting" Content="{l:Loc Settings_Splitting_RadioButton_ByTime}"
                                  IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
                         ConverterParameter={x:Static config:CuttingMode.ByTime}}" />
+                                <ToggleSwitch GroupName="Splitting" Name="CutByTitleToggleSwitch" Content="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"
+                                 IsChecked="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, 
+                        ConverterParameter={x:Static config:CuttingMode.ByTitle}}"/>
                             </StackPanel>
                         </local:SettingWithDefault>
                         <local:SettingWithDefault IsSettingNotUsingDefault="{Binding HasCuttingNumber}">

--- a/BililiveRecorder.WPF/Converters/FlagsEnumToBooleanConverter.cs
+++ b/BililiveRecorder.WPF/Converters/FlagsEnumToBooleanConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace BililiveRecorder.WPF.Converters
+{
+    internal class FlagsEnumToBooleanConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ((Enum)value).HasFlag((Enum)parameter);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value.Equals(true) ? parameter : Binding.DoNothing;
+        }
+    }
+}

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -78,6 +78,11 @@
                         <TextBlock Text="{l:Loc Settings_Splitting_TextBox_TimeUnit}" Visibility="{Binding ElementName=CutByTimeRadioButton,Path=IsChecked,Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"/>
                         <TextBlock Text="{l:Loc Settings_Splitting_TextBox_Right}"/>
                     </StackPanel>
+
+                    <ToggleSwitch GroupName="Splitting" Name="CutByTitleToggleSwitch" Content="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"
+                                IsChecked="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, 
+                        ConverterParameter={x:Static config:CuttingMode.ByTitle}}"/>
+
                 </StackPanel>
             </GroupBox>
             <GroupBox Header="直播封面">

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -79,9 +79,6 @@
                         <TextBlock Text="{l:Loc Settings_Splitting_TextBox_Right}"/>
                     </StackPanel>
 
-                    <RadioButton GroupName="Splitting" Name="CutByTitleToggleSwitch" Content="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"
-                                IsChecked="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, 
-                        ConverterParameter={x:Static config:CuttingMode.ByTitle}}"/>
                     <ui:ToggleSwitch IsOn="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, ConverterParameter={x:Static config:CuttingMode.ByTitle}}"
                                          OnContent="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}" OffContent="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"/>
 

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -79,9 +79,12 @@
                         <TextBlock Text="{l:Loc Settings_Splitting_TextBox_Right}"/>
                     </StackPanel>
 
-                    <ToggleSwitch GroupName="Splitting" Name="CutByTitleToggleSwitch" Content="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"
+                    <RadioButton GroupName="Splitting" Name="CutByTitleToggleSwitch" Content="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"
                                 IsChecked="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, 
                         ConverterParameter={x:Static config:CuttingMode.ByTitle}}"/>
+                    <ui:ToggleSwitch IsOn="{Binding Path=CuttingMode, Converter={StaticResource FlagsEnumToBooleanConverter}, ConverterParameter={x:Static config:CuttingMode.ByTitle}}"
+                                         OnContent="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}" OffContent="{l:Loc Settings_Splitting_ToggleSwitch_ByTitle}"/>
+
 
                 </StackPanel>
             </GroupBox>

--- a/BililiveRecorder.WPF/Properties/Strings.en.resx
+++ b/BililiveRecorder.WPF/Properties/Strings.en.resx
@@ -490,7 +490,10 @@ Only FLV is supported</value>
     <value>Split recording by video time</value>
   </data>
   <data name="Settings_Splitting_RadioButton_Disabled" xml:space="preserve">
-    <value>Disable</value>
+    <value>Don't split by file size or video time</value>
+  </data>
+  <data name="Settings_Splitting_ToggleSwitch_ByTitle" xml:space="preserve">
+    <value>Split recording by stream room title</value>
   </data>
   <data name="Settings_Splitting_TextBox_Left" xml:space="preserve">
     <value>Split recording every</value>

--- a/BililiveRecorder.WPF/Properties/Strings.resx
+++ b/BililiveRecorder.WPF/Properties/Strings.resx
@@ -490,7 +490,10 @@
     <value>根据视频时间自动分段</value>
   </data>
   <data name="Settings_Splitting_RadioButton_Disabled" xml:space="preserve">
-    <value>不自动分段</value>
+    <value>不要根据文件大小/视频时间自动分段</value>
+  </data>
+  <data name="Settings_Splitting_ToggleSwitch_ByTitle" xml:space="preserve">
+    <value>根据直播间标题自动分段</value>
   </data>
   <data name="Settings_Splitting_TextBox_Left" xml:space="preserve">
     <value>每</value>

--- a/BililiveRecorder.WPF/Resources/ConverterResources.xaml
+++ b/BililiveRecorder.WPF/Resources/ConverterResources.xaml
@@ -52,6 +52,7 @@
     <c:BooleanInverterConverter x:Key="BooleanInverterConverter"/>
     <c:ClipEnabledToBooleanConverter x:Key="ClipEnabledToBooleanConverter"/>
     <c:EnumToBooleanConverter x:Key="EnumToBooleanConverter"/>
+    <c:FlagsEnumToBooleanConverter x:Key="FlagsEnumToBooleanConverter"/>
     <c:IsNullToVisibilityConverter x:Key="IsNullToVisibilityCollapsedConverter"/>
     <c:RatioToColorBrushConverter x:Key="RatioToColorBrushConverter"/>
     <c:RatioToArrowIconConverter x:Key="RatioToArrowIconConverter" UpArrow="{StaticResource PathIconDataArrowUpBold}" DownArrow="{StaticResource PathIconDataArrowDownBold}"/>

--- a/test/BililiveRecorder.Core.UnitTests/Expectations/PublicApi.HasNoChangesAsync.verified.txt
+++ b/test/BililiveRecorder.Core.UnitTests/Expectations/PublicApi.HasNoChangesAsync.verified.txt
@@ -36,11 +36,13 @@ namespace BililiveRecorder.Core.Config
         public static string? SaveJson(BililiveRecorder.Core.Config.V3.ConfigV3 config) { }
         public static void WriteAllTextWithBackup(string path, string contents) { }
     }
+    [System.Flags]
     public enum CuttingMode
     {
         Disabled = 0,
         ByTime = 1,
         BySize = 2,
+        ByTitle = 4,
     }
     public enum DanmakuTransportMode
     {


### PR DESCRIPTION
### Overview

Splitting output video file according to stream room title proposed as a feature at #441. 

A new configure option is added accordingly. In the design level of BililiveRecorder, its splitting configuration strategy was selecting one option from many choices. It worked well when users don't usually need splitting by both file size and video length at the same time. Now if we want to introduce splitting by video stream title as a new cutting mode, I aware it's reasonable to enable this mode work together with every existing cutting mode.

Proposing in this PR, existing splitting modes remain in the same behaviours to the user, and "Split By Title" can perform as an additional layer over existing splitting modes.

### Core 
- Add `CuttingMode.ByTitle` to `BililiveRecorder.Core.Config`
- Update `BililiveRecorder.Core.Config.CuttingMode` from `enum` to `[System.Flags] enum` to fulfill increased complexity level of `CuttingMode` while maintaining compatibility to earlier version
- Add logic to split output file if room title changed to `BililiveRecorder.Core.Room` as per `Room_PropertyChanged` event

### WPF
- Add `FlagsEnumToBooleanConverter` to `BililiveRecorder.WPF.Converters`, with relevant implementations and references.
- Add WPF XAML GUI elements, where `CuttingMode.ByTitle` displayed as `<ui:ToggleSwitch>`
- Multi-language translations for new GUI elements

### Test
- Changed unit test file according to the change on BililiveRecorder.Core.Config

Please let me know if there are any concerns, warnings or errors.