### PR TITLE
feat(wpf): embed satellite assemblies into single exe

### DIFF
--- a/BililiveRecorder.WPF/BililiveRecorder.WPF.csproj
+++ b/BililiveRecorder.WPF/BililiveRecorder.WPF.csproj
@@ -332,6 +332,11 @@
     <PackageReference Include="CliWrap">
       <Version>3.3.2</Version>
     </PackageReference>
+    <PackageReference Include="Costura.Fody">
+      <Version>5.7.0</Version>
+      <IncludeAssets>runtime; compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf">
       <Version>1.1.0</Version>
     </PackageReference>
@@ -354,6 +359,9 @@
       <Version>6.3.3</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Resource.Embedder">
+      <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
       <Version>3.26.0</Version>
@@ -403,6 +411,9 @@
     <PackageReference Include="WpfLocalizeExtension">
       <Version>3.9.4</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Resource Include="FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release'">

--- a/BililiveRecorder.WPF/BililiveRecorder.nuspec
+++ b/BililiveRecorder.WPF/BililiveRecorder.nuspec
@@ -15,13 +15,5 @@
     <files>
         <file src="*" target="lib\net45\" exclude="*.nupkg;*.vshost.*;*.log;*.txt;NuGet.Squirrel.pdb"/>
         <file src="lib\*" target="lib\net45\lib\"/>
-        <file src="zh-Hans\*" target="lib\net45\zh-Hans\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
-        <file src="zh-Hant\*" target="lib\net45\zh-Hant\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
-        <file src="zh-CN\*" target="lib\net45\zh-CN\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
-        <file src="zh-TW\*" target="lib\net45\zh-TW\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
-        <file src="en\*" target="lib\net45\en\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
-        <file src="en-PN\*" target="lib\net45\en-PN\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
-        <file src="ja\*" target="lib\net45\ja\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
-        <file src="ja-JP\*" target="lib\net45\ja-JP\" exclude="**\*.nupkg;**\*.vshost.*;**\*.log;**\*.txt;**\Microsoft.VisualStudio.Threading.resources.dll;**\Microsoft.VisualStudio.Validation.resources.dll"/>
     </files>
 </package>

--- a/BililiveRecorder.WPF/FodyWeavers.xml
+++ b/BililiveRecorder.WPF/FodyWeavers.xml
@@ -1,0 +1,4 @@
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+	<Costura IgnoreSatelliteAssemblies='false' IncludeDebugSymbols='true'>
+	</Costura>
+</Weavers>


### PR DESCRIPTION
Hi，

这笔提交用于将WPF资源（运行时、翻译资源等）嵌入到独立的exe中：
![image](https://github.com/BililiveRecorder/BililiveRecorder/assets/17078589/ec70d823-a9cb-47e7-ab1a-a0f6bdf9db18)

您可以在这里查看CI的编译结果：
https://github.com/windowsair/BililiveRecorder/actions/runs/6656572220