### PR TITLE
fix(core): config-override from a directory

### DIFF
--- a/BililiveRecorder.Cli/Program.cs
+++ b/BililiveRecorder.Cli/Program.cs
@@ -130,8 +130,16 @@ namespace BililiveRecorder.Cli
 
             if (args.ConfigOverride is not null)
             {
-                logger.Information("Using config from {ConfigOverride}", args.ConfigOverride);
-                config = ConfigParser.LoadFromFile(args.ConfigOverride);
+                if (Directory.Exists(args.ConfigOverride))
+                {
+                    logger.Information("Using config from directory {ConfigOverride}", args.ConfigOverride);
+                    config = ConfigParser.LoadFromDirectory(path);
+                }  
+                else
+                {
+                    logger.Information("Using config from {ConfigOverride}", args.ConfigOverride);
+                    config = ConfigParser.LoadFromFile(args.ConfigOverride);
+                }
             }
             else
             {

--- a/BililiveRecorder.Core/Config/ConfigParser.cs
+++ b/BililiveRecorder.Core/Config/ConfigParser.cs
@@ -116,8 +116,17 @@ namespace BililiveRecorder.Core.Config
                 var filepath = Path.Combine(directory, CONFIG_FILE_NAME);
 
                 if (config.ConfigPathOverride is not null)
-                    filepath = config.ConfigPathOverride;
-
+                {
+                    if (config.ConfigPathOverride.EndsWith(".json"))
+                        filepath = config.ConfigPathOverride;
+                    else
+                    {
+                        logger.Information("Redirect overrided config path to {ConfigOverride}",Path.Combine(config.ConfigPathOverride,CONFIG_FILE_NAME));
+                        config.ConfigPathOverride = Path.Combine(config.ConfigPathOverride,CONFIG_FILE_NAME);
+                        filepath = config.ConfigPathOverride;
+                    }
+                }
+                
                 if (json is not null)
                     WriteAllTextWithBackup(filepath, json);
 

--- a/BililiveRecorder.Core/Config/ConfigParser.cs
+++ b/BililiveRecorder.Core/Config/ConfigParser.cs
@@ -117,14 +117,16 @@ namespace BililiveRecorder.Core.Config
 
                 if (config.ConfigPathOverride is not null)
                 {
-                    if (config.ConfigPathOverride.EndsWith(".json"))
+                    if (File.Exists(config.ConfigPathOverride))
                         filepath = config.ConfigPathOverride;
-                    else
+                    else if (Directory.Exists(config.ConfigPathOverride))
                     {
                         logger.Information("Redirect overrided config path to {ConfigOverride}",Path.Combine(config.ConfigPathOverride,CONFIG_FILE_NAME));
                         config.ConfigPathOverride = Path.Combine(config.ConfigPathOverride,CONFIG_FILE_NAME);
                         filepath = config.ConfigPathOverride;
                     }
+                    else
+                        logger.Error("Error config-override Path");
                 }
                 
                 if (json is not null)


### PR DESCRIPTION
这个PR是为了解决问题 #590 在config-override中指定路径时无法正常初始化，必须指定为某个具体的可序列化文件的问题

由于在LoadFromFile中已经实现了初始化的部分，经检查问题在于在保存时会将保存路径+json文件名覆盖为指定路径，File无法对路径进行写入，故产生错误

修改后如果config-override指定为目录时，会自动在当前目录下生成config.json（但是会对原有的config进行覆盖），可以解决报错的问题