### PR TITLE
feat: Optimize the way to get 'gosu' files

### DIFF
--- a/Dockerfile.GitHubActions
+++ b/Dockerfile.GitHubActions
@@ -13,6 +13,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY ./BililiveRecorder.Cli/bin/docker_out /app
 
 RUN chmod a+x /usr/local/bin/docker-entrypoint.sh && \
+    chmod -R 777 /app && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone
 

--- a/Dockerfile.GitHubActions
+++ b/Dockerfile.GitHubActions
@@ -1,31 +1,20 @@
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
 ENV TZ=Asia/Shanghai
-ENV GOSU_VERSION=1.17
 
 ENV UMASK=022
-ENV PUID=1000
-ENV PGID=1000
-
+ENV PUID=0
+ENV PGID=0
 
 WORKDIR /app
 VOLUME [ "/rec" ]
 
+COPY --from=tianon/gosu /gosu /usr/local/bin/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY ./BililiveRecorder.Cli/bin/docker_out /app
 
-RUN apt-get update && \
-    apt-get install -y wget && \
-    rm -rf /var/lib/apt/lists/* && \
-    useradd -r -g users user && \
-    chmod a+x /usr/local/bin/docker-entrypoint.sh && \
+RUN chmod a+x /usr/local/bin/docker-entrypoint.sh && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone
-
-ARG TARGETPLATFORM
-
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then wget -O /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64; fi; if [ "$TARGETPLATFORM" = "linux/arm64" ]; then wget -O /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-arm64; fi; if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then wget -O /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-armhf; fi
-
-RUN chmod +x /usr/local/bin/gosu
 
 EXPOSE 2356/tcp
 

--- a/Dockerfile.GitHubActions
+++ b/Dockerfile.GitHubActions
@@ -8,7 +8,7 @@ ENV PGID=0
 WORKDIR /app
 VOLUME [ "/rec" ]
 
-COPY --from=tianon/gosu /gosu /usr/local/bin/
+COPY --from=tianon/gosu:1.17 /gosu /usr/local/bin/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY ./BililiveRecorder.Cli/bin/docker_out /app
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,12 +4,9 @@ set -e
 
 umask $UMASK
 
-usermod -u $PUID user
-groupmod -g $PGID users
-
-chown -R user:users /app
-chown -R user:users /rec
+chown -R ${PUID}:${PGID} /app
+chown -R ${PUID}:${PGID} /rec
 
 export HOME=/home/user
 
-exec /usr/local/bin/gosu user dotnet /app/BililiveRecorder.Cli.dll $@
+exec /usr/local/bin/gosu ${PUID}:${PGID} dotnet /app/BililiveRecorder.Cli.dll $@


### PR DESCRIPTION
对比之前的版本，优化了gosu文件获取的方式，选择直接从官方的镜像中复制出来二进制文件。

[参考gosu官方文档](https://github.com/tianon/gosu/blob/master/INSTALL.md#others--lazy-method)

采用了 #588 中 @kira1928 提到的权限配置方式，不再创建新用户而是使用对应的ID直接运行，并且将默认的UID和PID设置为了0(对应root用户)，进一步减少发生权限错误的可能。  