### PR TITLE
feat(cli/core): add TitleFilterPatterns option

### DIFF
--- a/BililiveRecorder.Cli/Configure/ConfigInstructions.gen.cs
+++ b/BililiveRecorder.Cli/Configure/ConfigInstructions.gen.cs
@@ -28,6 +28,7 @@ namespace BililiveRecorder.Cli.Configure
         FileNameRecordTemplate,
         FlvProcessorSplitOnScriptTag,
         FlvWriteMetadata,
+        TitleFilterPatterns,
         WebHookUrls,
         WebHookUrlsV2,
         WpfShowTitleAndArea,
@@ -65,7 +66,8 @@ namespace BililiveRecorder.Cli.Configure
         RecordDanmakuGuard,
         SaveStreamCover,
         RecordingQuality,
-        FlvProcessorSplitOnScriptTag
+        FlvProcessorSplitOnScriptTag,
+        TitleFilterPatterns
     }
     public static class ConfigInstructions
     {
@@ -88,6 +90,7 @@ namespace BililiveRecorder.Cli.Configure
             GlobalConfig.Add(GlobalConfigProperties.FileNameRecordTemplate, new ConfigInstruction<GlobalConfig, string>(config => config.HasFileNameRecordTemplate = false, (config, value) => config.FileNameRecordTemplate = value) { Name = "FileNameRecordTemplate", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.FlvProcessorSplitOnScriptTag, new ConfigInstruction<GlobalConfig, bool>(config => config.HasFlvProcessorSplitOnScriptTag = false, (config, value) => config.FlvProcessorSplitOnScriptTag = value) { Name = "FlvProcessorSplitOnScriptTag", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.FlvWriteMetadata, new ConfigInstruction<GlobalConfig, bool>(config => config.HasFlvWriteMetadata = false, (config, value) => config.FlvWriteMetadata = value) { Name = "FlvWriteMetadata", CanBeOptional = true });
+            GlobalConfig.Add(GlobalConfigProperties.TitleFilterPatterns, new ConfigInstruction<GlobalConfig, string>(config => config.HasTitleFilterPatterns = false, (config, value) => config.TitleFilterPatterns = value) { Name = "TitleFilterPatterns", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.WebHookUrls, new ConfigInstruction<GlobalConfig, string>(config => config.HasWebHookUrls = false, (config, value) => config.WebHookUrls = value) { Name = "WebHookUrls", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.WebHookUrlsV2, new ConfigInstruction<GlobalConfig, string>(config => config.HasWebHookUrlsV2 = false, (config, value) => config.WebHookUrlsV2 = value) { Name = "WebHookUrlsV2", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.WpfShowTitleAndArea, new ConfigInstruction<GlobalConfig, bool>(config => config.HasWpfShowTitleAndArea = false, (config, value) => config.WpfShowTitleAndArea = value) { Name = "WpfShowTitleAndArea", CanBeOptional = true });
@@ -122,6 +125,7 @@ namespace BililiveRecorder.Cli.Configure
             RoomConfig.Add(RoomConfigProperties.SaveStreamCover, new ConfigInstruction<RoomConfig, bool>(config => config.HasSaveStreamCover = false, (config, value) => config.SaveStreamCover = value) { Name = "SaveStreamCover", CanBeOptional = true });
             RoomConfig.Add(RoomConfigProperties.RecordingQuality, new ConfigInstruction<RoomConfig, string>(config => config.HasRecordingQuality = false, (config, value) => config.RecordingQuality = value) { Name = "RecordingQuality", CanBeOptional = true });
             RoomConfig.Add(RoomConfigProperties.FlvProcessorSplitOnScriptTag, new ConfigInstruction<RoomConfig, bool>(config => config.HasFlvProcessorSplitOnScriptTag = false, (config, value) => config.FlvProcessorSplitOnScriptTag = value) { Name = "FlvProcessorSplitOnScriptTag", CanBeOptional = true });
+            RoomConfig.Add(RoomConfigProperties.TitleFilterPatterns, new ConfigInstruction<RoomConfig, string>(config => config.HasTitleFilterPatterns = false, (config, value) => config.TitleFilterPatterns = value) { Name = "TitleFilterPatterns", CanBeOptional = true });
         }
     }
 

--- a/BililiveRecorder.Core/Config/V3/Config.gen.cs
+++ b/BililiveRecorder.Core/Config/V3/Config.gen.cs
@@ -126,6 +126,14 @@ namespace BililiveRecorder.Core.Config.V3
         public Optional<bool> OptionalFlvProcessorSplitOnScriptTag { get => this.GetPropertyValueOptional<bool>(nameof(this.FlvProcessorSplitOnScriptTag)); set => this.SetPropertyValueOptional(value, nameof(this.FlvProcessorSplitOnScriptTag)); }
 
         /// <summary>
+        /// 标题过滤
+        /// </summary>
+        public string? TitleFilterPatterns { get => this.GetPropertyValue<string>(); set => this.SetPropertyValue(value); }
+        public bool HasTitleFilterPatterns { get => this.GetPropertyHasValue(nameof(this.TitleFilterPatterns)); set => this.SetPropertyHasValue<string>(value, nameof(this.TitleFilterPatterns)); }
+        [JsonProperty(nameof(TitleFilterPatterns)), EditorBrowsable(EditorBrowsableState.Never)]
+        public Optional<string?> OptionalTitleFilterPatterns { get => this.GetPropertyValueOptional<string>(nameof(this.TitleFilterPatterns)); set => this.SetPropertyValueOptional(value, nameof(this.TitleFilterPatterns)); }
+
+        /// <summary>
         /// 录制文件名模板
         /// </summary>
         public string? FileNameRecordTemplate => this.GetPropertyValue<string>();
@@ -348,6 +356,14 @@ namespace BililiveRecorder.Core.Config.V3
         public Optional<bool> OptionalFlvWriteMetadata { get => this.GetPropertyValueOptional<bool>(nameof(this.FlvWriteMetadata)); set => this.SetPropertyValueOptional(value, nameof(this.FlvWriteMetadata)); }
 
         /// <summary>
+        /// 标题过滤
+        /// </summary>
+        public string? TitleFilterPatterns { get => this.GetPropertyValue<string>(); set => this.SetPropertyValue(value); }
+        public bool HasTitleFilterPatterns { get => this.GetPropertyHasValue(nameof(this.TitleFilterPatterns)); set => this.SetPropertyHasValue<string>(value, nameof(this.TitleFilterPatterns)); }
+        [JsonProperty(nameof(TitleFilterPatterns)), EditorBrowsable(EditorBrowsableState.Never)]
+        public Optional<string?> OptionalTitleFilterPatterns { get => this.GetPropertyValueOptional<string>(nameof(this.TitleFilterPatterns)); set => this.SetPropertyValueOptional(value, nameof(this.TitleFilterPatterns)); }
+
+        /// <summary>
         /// WebhookV1
         /// </summary>
         public string? WebHookUrls { get => this.GetPropertyValue<string>(); set => this.SetPropertyValue(value); }
@@ -533,6 +549,8 @@ namespace BililiveRecorder.Core.Config.V3
         public bool FlvProcessorSplitOnScriptTag => false;
 
         public bool FlvWriteMetadata => true;
+
+        public string TitleFilterPatterns => @"";
 
         public string WebHookUrls => @"";
 

--- a/BililiveRecorder.Core/Config/V3/Config.gen.cs
+++ b/BililiveRecorder.Core/Config/V3/Config.gen.cs
@@ -126,7 +126,7 @@ namespace BililiveRecorder.Core.Config.V3
         public Optional<bool> OptionalFlvProcessorSplitOnScriptTag { get => this.GetPropertyValueOptional<bool>(nameof(this.FlvProcessorSplitOnScriptTag)); set => this.SetPropertyValueOptional(value, nameof(this.FlvProcessorSplitOnScriptTag)); }
 
         /// <summary>
-        /// 标题过滤
+        /// 不录制的标题匹配正则
         /// </summary>
         public string? TitleFilterPatterns { get => this.GetPropertyValue<string>(); set => this.SetPropertyValue(value); }
         public bool HasTitleFilterPatterns { get => this.GetPropertyHasValue(nameof(this.TitleFilterPatterns)); set => this.SetPropertyHasValue<string>(value, nameof(this.TitleFilterPatterns)); }
@@ -356,7 +356,7 @@ namespace BililiveRecorder.Core.Config.V3
         public Optional<bool> OptionalFlvWriteMetadata { get => this.GetPropertyValueOptional<bool>(nameof(this.FlvWriteMetadata)); set => this.SetPropertyValueOptional(value, nameof(this.FlvWriteMetadata)); }
 
         /// <summary>
-        /// 标题过滤
+        /// 不录制的标题匹配正则
         /// </summary>
         public string? TitleFilterPatterns { get => this.GetPropertyValue<string>(); set => this.SetPropertyValue(value); }
         public bool HasTitleFilterPatterns { get => this.GetPropertyHasValue(nameof(this.TitleFilterPatterns)); set => this.SetPropertyHasValue<string>(value, nameof(this.TitleFilterPatterns)); }

--- a/BililiveRecorder.Core/Room.cs
+++ b/BililiveRecorder.Core/Room.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using BililiveRecorder.Core.Api;
@@ -228,14 +229,24 @@ namespace BililiveRecorder.Core
             }
         }
 
-        private bool ValidateTitle()
+        private static readonly TimeSpan TitleRegexMatchTimeout = TimeSpan.FromSeconds(0.5);
+
+        /// <exception cref="ArgumentException" />
+        /// <exception cref="RegexMatchTimeoutException" />
+        private bool DoesTitleAllowRecord()
         {
-            var patterns = this.RoomConfig.TitleFilterPatterns?.Split(',');
-            foreach (var pattern in patterns ?? Array.Empty<string>())
+            // 按新行分割的正则表达式
+            var patterns = this.RoomConfig.TitleFilterPatterns?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (patterns is null || patterns.Length == 0)
+                return true;
+
+            foreach (var pattern in patterns)
             {
-                if (this.Title.Contains(pattern))
+                if (Regex.IsMatch(input: this.Title, pattern: pattern, options: RegexOptions.None, matchTimeout: TitleRegexMatchTimeout))
                     return false;
             }
+
             return true;
         }
 
@@ -253,10 +264,17 @@ namespace BililiveRecorder.Core
                 if (this.recordTask != null)
                     return;
 
-                if (!this.ValidateTitle())
+                try
                 {
-                    this.logger.Information("标题不符合要求，不录制");
-                    return;
+                    if (!this.DoesTitleAllowRecord())
+                    {
+                        this.logger.Information("标题匹配到跳过录制设置中的规则，不录制");
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    this.logger.Warning(ex, "检查标题是否匹配跳过录制正则表达式时出错");
                 }
 
                 var task = this.recordTaskFactory.CreateRecordTask(this);
@@ -688,7 +706,8 @@ retry:
                     }
                     break;
                 case nameof(this.Title):
-                    if (this.RoomConfig.CuttingByTitle){
+                    if (this.RoomConfig.CuttingByTitle)
+                    {
                         this.SplitOutput();
                     }
                     break;

--- a/BililiveRecorder.Core/Room.cs
+++ b/BililiveRecorder.Core/Room.cs
@@ -228,6 +228,17 @@ namespace BililiveRecorder.Core
             }
         }
 
+        private bool ValidateTitle()
+        {
+            var patterns = this.RoomConfig.TitleFilterPatterns?.Split(',');
+            foreach (var pattern in patterns ?? Array.Empty<string>())
+            {
+                if (this.Title.Contains(pattern))
+                    return false;
+            }
+            return true;
+        }
+
         ///
         private void CreateAndStartNewRecordTask(bool skipFetchRoomInfo = false)
         {
@@ -241,6 +252,12 @@ namespace BililiveRecorder.Core
 
                 if (this.recordTask != null)
                     return;
+
+                if (!this.ValidateTitle())
+                {
+                    this.logger.Information("标题不符合要求，不录制");
+                    return;
+                }
 
                 var task = this.recordTaskFactory.CreateRecordTask(this);
                 task.IOStats += this.RecordTask_IOStats;
@@ -652,6 +669,7 @@ retry:
                 });
             }
         }
+
 
         private void Room_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {

--- a/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
+++ b/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
@@ -113,6 +113,15 @@
                         </local:SettingWithDefault>
                     </StackPanel>
                 </GroupBox>
+                <GroupBox Header="录制条件">
+                    <StackPanel>
+                        <TextBlock Margin="5" Text="跳过录制的直播标题正则匹配表达式，每行一个" />
+                        <local:SettingWithDefault IsSettingNotUsingDefault="{Binding HasTitleFilterPatterns}">
+                            <TextBox Margin="5" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible"
+                                Text="{Binding TitleFilterPatterns,UpdateSourceTrigger=PropertyChanged,Delay=1000}" ui:TextBoxHelper.IsDeleteButtonVisible="False"/>
+                        </local:SettingWithDefault>
+                    </StackPanel>
+                </GroupBox>
             </ui:SimpleStackPanel>
         </ScrollViewer>
     </Grid>

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -131,6 +131,13 @@
                     </c:SettingWithDefault>
                 </StackPanel>
             </GroupBox>
+            <GroupBox Header="录制条件">
+                <StackPanel>
+                    <TextBlock Margin="5" Text="跳过录制的直播标题正则匹配表达式，每行一个" />
+                    <TextBox Margin="5" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible"
+                         Text="{Binding TitleFilterPatterns,UpdateSourceTrigger=PropertyChanged,Delay=1000}" ui:TextBoxHelper.IsDeleteButtonVisible="False"/>
+                </StackPanel>
+            </GroupBox>
             <GroupBox Header="{l:Loc Settings_Webhook_Title}">
                 <StackPanel MaxWidth="400" HorizontalAlignment="Left">
                     <TextBlock Text="{l:Loc Settings_Webhook_Address}" Margin="0,0,0,10"/>

--- a/BililiveRecorder.Web/Models/Config.gen.cs
+++ b/BililiveRecorder.Web/Models/Config.gen.cs
@@ -25,6 +25,7 @@ namespace BililiveRecorder.Web.Models
         public Optional<bool>? OptionalSaveStreamCover { get; set; }
         public Optional<string?>? OptionalRecordingQuality { get; set; }
         public Optional<bool>? OptionalFlvProcessorSplitOnScriptTag { get; set; }
+        public Optional<string?>? OptionalTitleFilterPatterns { get; set; }
 
         public void ApplyTo(RoomConfig config)
         {
@@ -41,6 +42,7 @@ namespace BililiveRecorder.Web.Models
             if (this.OptionalSaveStreamCover.HasValue) config.OptionalSaveStreamCover = this.OptionalSaveStreamCover.Value;
             if (this.OptionalRecordingQuality.HasValue) config.OptionalRecordingQuality = this.OptionalRecordingQuality.Value;
             if (this.OptionalFlvProcessorSplitOnScriptTag.HasValue) config.OptionalFlvProcessorSplitOnScriptTag = this.OptionalFlvProcessorSplitOnScriptTag.Value;
+            if (this.OptionalTitleFilterPatterns.HasValue) config.OptionalTitleFilterPatterns = this.OptionalTitleFilterPatterns.Value;
         }
     }
 
@@ -60,6 +62,7 @@ namespace BililiveRecorder.Web.Models
         public Optional<string?>? OptionalFileNameRecordTemplate { get; set; }
         public Optional<bool>? OptionalFlvProcessorSplitOnScriptTag { get; set; }
         public Optional<bool>? OptionalFlvWriteMetadata { get; set; }
+        public Optional<string?>? OptionalTitleFilterPatterns { get; set; }
         public Optional<string?>? OptionalWebHookUrls { get; set; }
         public Optional<string?>? OptionalWebHookUrlsV2 { get; set; }
         public Optional<bool>? OptionalWpfShowTitleAndArea { get; set; }
@@ -96,6 +99,7 @@ namespace BililiveRecorder.Web.Models
             if (this.OptionalFileNameRecordTemplate.HasValue) config.OptionalFileNameRecordTemplate = this.OptionalFileNameRecordTemplate.Value;
             if (this.OptionalFlvProcessorSplitOnScriptTag.HasValue) config.OptionalFlvProcessorSplitOnScriptTag = this.OptionalFlvProcessorSplitOnScriptTag.Value;
             if (this.OptionalFlvWriteMetadata.HasValue) config.OptionalFlvWriteMetadata = this.OptionalFlvWriteMetadata.Value;
+            if (this.OptionalTitleFilterPatterns.HasValue) config.OptionalTitleFilterPatterns = this.OptionalTitleFilterPatterns.Value;
             if (this.OptionalWebHookUrls.HasValue) config.OptionalWebHookUrls = this.OptionalWebHookUrls.Value;
             if (this.OptionalWebHookUrlsV2.HasValue) config.OptionalWebHookUrlsV2 = this.OptionalWebHookUrlsV2.Value;
             if (this.OptionalWpfShowTitleAndArea.HasValue) config.OptionalWpfShowTitleAndArea = this.OptionalWpfShowTitleAndArea.Value;
@@ -137,6 +141,7 @@ namespace BililiveRecorder.Web.Models.Rest
         public Optional<bool> OptionalSaveStreamCover { get; set; }
         public Optional<string?> OptionalRecordingQuality { get; set; }
         public Optional<bool> OptionalFlvProcessorSplitOnScriptTag { get; set; }
+        public Optional<string?> OptionalTitleFilterPatterns { get; set; }
     }
 
     public class GlobalConfigDto
@@ -155,6 +160,7 @@ namespace BililiveRecorder.Web.Models.Rest
         public Optional<string?> OptionalFileNameRecordTemplate { get; set; }
         public Optional<bool> OptionalFlvProcessorSplitOnScriptTag { get; set; }
         public Optional<bool> OptionalFlvWriteMetadata { get; set; }
+        public Optional<string?> OptionalTitleFilterPatterns { get; set; }
         public Optional<string?> OptionalWebHookUrls { get; set; }
         public Optional<string?> OptionalWebHookUrlsV2 { get; set; }
         public Optional<bool> OptionalWpfShowTitleAndArea { get; set; }
@@ -198,6 +204,7 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.OptionalSaveStreamCover, type: typeof(HierarchicalOptionalType<bool>));
             this.Field(x => x.OptionalRecordingQuality, type: typeof(HierarchicalOptionalType<string>));
             this.Field(x => x.OptionalFlvProcessorSplitOnScriptTag, type: typeof(HierarchicalOptionalType<bool>));
+            this.Field(x => x.OptionalTitleFilterPatterns, type: typeof(HierarchicalOptionalType<string>));
         }
     }
 
@@ -219,6 +226,7 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.OptionalFileNameRecordTemplate, type: typeof(HierarchicalOptionalType<string>));
             this.Field(x => x.OptionalFlvProcessorSplitOnScriptTag, type: typeof(HierarchicalOptionalType<bool>));
             this.Field(x => x.OptionalFlvWriteMetadata, type: typeof(HierarchicalOptionalType<bool>));
+            this.Field(x => x.OptionalTitleFilterPatterns, type: typeof(HierarchicalOptionalType<string>));
             this.Field(x => x.OptionalWebHookUrls, type: typeof(HierarchicalOptionalType<string>));
             this.Field(x => x.OptionalWebHookUrlsV2, type: typeof(HierarchicalOptionalType<string>));
             this.Field(x => x.OptionalWpfShowTitleAndArea, type: typeof(HierarchicalOptionalType<bool>));
@@ -259,6 +267,7 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.FileNameRecordTemplate);
             this.Field(x => x.FlvProcessorSplitOnScriptTag);
             this.Field(x => x.FlvWriteMetadata);
+            this.Field(x => x.TitleFilterPatterns);
             this.Field(x => x.WebHookUrls);
             this.Field(x => x.WebHookUrlsV2);
             this.Field(x => x.WpfShowTitleAndArea);
@@ -298,6 +307,7 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.OptionalSaveStreamCover, nullable: true, type: typeof(HierarchicalOptionalInputType<bool>));
             this.Field(x => x.OptionalRecordingQuality, nullable: true, type: typeof(HierarchicalOptionalInputType<string>));
             this.Field(x => x.OptionalFlvProcessorSplitOnScriptTag, nullable: true, type: typeof(HierarchicalOptionalInputType<bool>));
+            this.Field(x => x.OptionalTitleFilterPatterns, nullable: true, type: typeof(HierarchicalOptionalInputType<string>));
         }
     }
 
@@ -319,6 +329,7 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.OptionalFileNameRecordTemplate, nullable: true, type: typeof(HierarchicalOptionalInputType<string>));
             this.Field(x => x.OptionalFlvProcessorSplitOnScriptTag, nullable: true, type: typeof(HierarchicalOptionalInputType<bool>));
             this.Field(x => x.OptionalFlvWriteMetadata, nullable: true, type: typeof(HierarchicalOptionalInputType<bool>));
+            this.Field(x => x.OptionalTitleFilterPatterns, nullable: true, type: typeof(HierarchicalOptionalInputType<string>));
             this.Field(x => x.OptionalWebHookUrls, nullable: true, type: typeof(HierarchicalOptionalInputType<string>));
             this.Field(x => x.OptionalWebHookUrlsV2, nullable: true, type: typeof(HierarchicalOptionalInputType<string>));
             this.Field(x => x.OptionalWpfShowTitleAndArea, nullable: true, type: typeof(HierarchicalOptionalInputType<bool>));

--- a/configV3.schema.json
+++ b/configV3.schema.json
@@ -577,6 +577,22 @@
               "default": false
             }
           }
+        },
+        "TitleFilterPatterns": {
+          "description": "标题过滤\n默认: ",
+          "markdownDescription": "标题过滤  \n默认: ` `\n\n",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "HasValue": {
+              "type": "boolean",
+              "default": true
+            },
+            "Value": {
+              "type": "string",
+              "default": ""
+            }
+          }
         }
       }
     },
@@ -820,6 +836,22 @@
             "Value": {
               "type": "boolean",
               "default": false
+            }
+          }
+        },
+        "TitleFilterPatterns": {
+          "description": "标题过滤\n默认: ",
+          "markdownDescription": "标题过滤  \n默认: ` `\n\n",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "HasValue": {
+              "type": "boolean",
+              "default": true
+            },
+            "Value": {
+              "type": "string",
+              "default": ""
             }
           }
         }

--- a/configV3.schema.json
+++ b/configV3.schema.json
@@ -579,8 +579,8 @@
           }
         },
         "TitleFilterPatterns": {
-          "description": "标题过滤\n默认: ",
-          "markdownDescription": "标题过滤  \n默认: ` `\n\n",
+          "description": "不录制的标题匹配正则\n默认: ",
+          "markdownDescription": "不录制的标题匹配正则  \n默认: ` `\n\n",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -840,8 +840,8 @@
           }
         },
         "TitleFilterPatterns": {
-          "description": "标题过滤\n默认: ",
-          "markdownDescription": "标题过滤  \n默认: ` `\n\n",
+          "description": "不录制的标题匹配正则\n默认: ",
+          "markdownDescription": "不录制的标题匹配正则  \n默认: ` `\n\n",
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/config_gen/data.ts
+++ b/config_gen/data.ts
@@ -117,7 +117,7 @@ export const data: Array<ConfigEntry> = [
     },
     {
         id: "TitleFilterPatterns",
-        name: "标题过滤",
+        name: "不录制的标题匹配正则",
         type: "string?",
         configType: "room",
         default: ""

--- a/config_gen/data.ts
+++ b/config_gen/data.ts
@@ -116,6 +116,13 @@ export const data: Array<ConfigEntry> = [
         default: true
     },
     {
+        id: "TitleFilterPatterns",
+        name: "标题过滤",
+        type: "string?",
+        configType: "room",
+        default: ""
+    },
+    {
         id: "WebHookUrls",
         name: "WebhookV1",
         type: "string?",


### PR DESCRIPTION
## 动机

主要针对自动录制情况下想要跳过某些直播场次以节省存储、带宽

比如如果标题固定存在“二台”就跳过录制

## 说明

`TitleFilterPatterns`参数为`pattern1,pattern2,...`的形式（`pattern`不包含`,`）

鉴于该场景下并不需要复杂的字符串匹配机制，一般以单词的形式出现，
`pattern`不包含`,`的条件应很容易满足

由于能力有限，仅实现并测试了cli

<img width="210" alt="{BDEB9A4F-94F6-4429-B926-F0CC4F0C1B78}" src="https://github.com/user-attachments/assets/0d9b7acb-962c-47fc-918f-e69552ecf623">
