### PR TITLE
解决输入 Cookies 时最后一项没有分号就不能正确读取的问题

### DIFF
--- a/BililiveRecorder.Core/Api/Http/HttpApiClient.cs
+++ b/BililiveRecorder.Core/Api/Http/HttpApiClient.cs
@@ -22,8 +22,8 @@ namespace BililiveRecorder.Core.Api.Http
         internal const string HttpHeaderReferer = "https://live.bilibili.com/";
         internal const string HttpHeaderOrigin = "https://live.bilibili.com";
         internal const string HttpHeaderUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36 Edg/132.0.0.0";
-        private static readonly Regex matchCookieUidRegex = new Regex(@"DedeUserID=(\d+?);", RegexOptions.Compiled);
-        private static readonly Regex matchCookieBuvid3Regex = new Regex(@"buvid3=(.+?);", RegexOptions.Compiled);
+        private static readonly Regex matchCookieUidRegex = new Regex(@"DedeUserID=(\d+?);?(?=\b|$)", RegexOptions.Compiled);
+        private static readonly Regex matchCookieBuvid3Regex = new Regex(@"buvid3=(.+?);?(?=\b|$)", RegexOptions.Compiled);
         private long uid;
         private string? buvid3;
 


### PR DESCRIPTION
解决 WPF 的高级设置里输入 Cookie 时，DedeUserID 或者 buvid3 是最后一项且没有分号就无法匹配的问题