### PR TITLE
Add single-file publish commands & Bump target frameworks to net10.0 添加了单一可执行文件的构建命令 & 升级目标框架为net10.0

### DIFF
--- a/BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
+++ b/BililiveRecorder.Cli/BililiveRecorder.Cli.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <StartupObject>BililiveRecorder.Cli.Program</StartupObject>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>

--- a/BililiveRecorder.Core/BililiveRecorder.Core.csproj
+++ b/BililiveRecorder.Core/BililiveRecorder.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/BililiveRecorder.Web/BililiveRecorder.Web.csproj
+++ b/BililiveRecorder.Web/BililiveRecorder.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>

--- a/README.md
+++ b/README.md
@@ -77,6 +77,37 @@ git submodule update --init --recursive
 dotnet build BililiveRecorder.Cli
 ```
 
+Publish a single-file executable (CLI):
+
+```sh
+# Build WebUI, optional
+git submodule update --init --recursive
+./webui/build.sh
+
+# Windows x64 single-file executable
+dotnet publish BililiveRecorder.Cli -c Release -r win-x64 --self-contained -p:PublishSingleFile=true
+
+# Windows ARM64 single-file executable
+dotnet publish BililiveRecorder.Cli -c Release -r win-arm64 --self-contained -p:PublishSingleFile=true
+
+# macOS x64 / Apple Silicon
+dotnet publish BililiveRecorder.Cli -c Release -r osx-x64 --self-contained -p:PublishSingleFile=true
+dotnet publish BililiveRecorder.Cli -c Release -r osx-arm64 --self-contained -p:PublishSingleFile=true
+
+# Linux x64 / ARM64
+dotnet publish BililiveRecorder.Cli -c Release -r linux-x64 --self-contained -p:PublishSingleFile=true
+dotnet publish BililiveRecorder.Cli -c Release -r linux-arm64 --self-contained -p:PublishSingleFile=true
+
+# Linux ARM (32-bit)
+dotnet publish BililiveRecorder.Cli -c Release -r linux-arm --self-contained -p:PublishSingleFile=true
+
+# Linux musl (Alpine)
+dotnet publish BililiveRecorder.Cli -c Release -r linux-musl-x64 --self-contained -p:PublishSingleFile=true
+dotnet publish BililiveRecorder.Cli -c Release -r linux-musl-arm64 --self-contained -p:PublishSingleFile=true
+
+# Output: BililiveRecorder.Cli/publish/<rid>/Release/
+```
+
 ## Project structure
 
 Project | Target |

--- a/README_CN.md
+++ b/README_CN.md
@@ -65,6 +65,37 @@ git submodule update --init --recursive
 dotnet build BililiveRecorder.Cli
 ```
 
+打包单文件可执行程序（CLI）：
+
+```sh
+# Build WebUI, optional
+git submodule update --init --recursive
+./webui/build.sh
+
+# Windows x64 单文件可执行程序
+dotnet publish BililiveRecorder.Cli -c Release -r win-x64 --self-contained -p:PublishSingleFile=true
+
+# Windows ARM64 单文件可执行程序
+dotnet publish BililiveRecorder.Cli -c Release -r win-arm64 --self-contained -p:PublishSingleFile=true
+
+# macOS x64 / Apple Silicon
+dotnet publish BililiveRecorder.Cli -c Release -r osx-x64 --self-contained -p:PublishSingleFile=true
+dotnet publish BililiveRecorder.Cli -c Release -r osx-arm64 --self-contained -p:PublishSingleFile=true
+
+# Linux x64 / ARM64
+dotnet publish BililiveRecorder.Cli -c Release -r linux-x64 --self-contained -p:PublishSingleFile=true
+dotnet publish BililiveRecorder.Cli -c Release -r linux-arm64 --self-contained -p:PublishSingleFile=true
+
+# Linux ARM (32-bit)
+dotnet publish BililiveRecorder.Cli -c Release -r linux-arm --self-contained -p:PublishSingleFile=true
+
+# Linux musl (Alpine)
+dotnet publish BililiveRecorder.Cli -c Release -r linux-musl-x64 --self-contained -p:PublishSingleFile=true
+dotnet publish BililiveRecorder.Cli -c Release -r linux-musl-arm64 --self-contained -p:PublishSingleFile=true
+
+# 产物目录：BililiveRecorder.Cli/publish/<rid>/Release/
+```
+
 ## 项目结构
 
 Project | Target |

--- a/test/BililiveRecorder.Core.UnitTests/BililiveRecorder.Core.UnitTests.csproj
+++ b/test/BililiveRecorder.Core.UnitTests/BililiveRecorder.Core.UnitTests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net4.8;net8.0</TargetFrameworks>
-    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">net8.0</TargetFramework>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net4.8;net10.0</TargetFrameworks>
+    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/BililiveRecorder.Flv.Tests/BililiveRecorder.Flv.Tests.csproj
+++ b/test/BililiveRecorder.Flv.Tests/BililiveRecorder.Flv.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- docs(readme): add single-file publish commands 添加了单一可执行文件的构建命令
- chore(build): bump target frameworks to net10.0 升级目标框架为net10.0