### PR TITLE
feat(wpf): add dropdown UI for recording quality settings

### DIFF
--- a/BililiveRecorder.WPF/BililiveRecorder.WPF.csproj
+++ b/BililiveRecorder.WPF/BililiveRecorder.WPF.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Models\DanmakuFileWithOffset.cs" />
     <Compile Include="Models\LogModel.cs" />
     <Compile Include="Models\PollyPolicyModel.cs" />
+    <Compile Include="Models\RecordingQualityHelper.cs" />
     <Compile Include="Models\RootModel.cs" />
     <Compile Include="NetworkChangeDetector.cs" />
     <Compile Include="Pages\AboutPage.xaml.cs">

--- a/BililiveRecorder.WPF/Models/RecordingQualityHelper.cs
+++ b/BililiveRecorder.WPF/Models/RecordingQualityHelper.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+namespace BililiveRecorder.WPF.Models
+{
+    public enum CodecPreference
+    {
+        AvcFirst,
+        HevcFirst,
+        AvcOnly,
+        HevcOnly,
+    }
+
+    public class CodecPreferenceItem
+    {
+        public CodecPreference Value { get; }
+        public string DisplayName { get; }
+
+        public CodecPreferenceItem(CodecPreference value, string displayName)
+        {
+            this.Value = value;
+            this.DisplayName = displayName;
+        }
+
+        public override string ToString() => this.DisplayName;
+    }
+
+    public class QualityItem
+    {
+        public int Qn { get; }
+        public string DisplayName { get; }
+
+        public QualityItem(int qn, string displayName)
+        {
+            this.Qn = qn;
+            this.DisplayName = displayName;
+        }
+
+        public override string ToString() => this.DisplayName;
+    }
+
+    public static class RecordingQualityHelper
+    {
+        public static readonly CodecPreferenceItem[] CodecPreferenceItems = new[]
+        {
+            new CodecPreferenceItem(CodecPreference.AvcFirst, "AVC 优先 (先 H.264, 后 H.265)"),
+            new CodecPreferenceItem(CodecPreference.HevcFirst, "HEVC 优先 (先 H.265, 后 H.264)"),
+            new CodecPreferenceItem(CodecPreference.AvcOnly, "仅 AVC (H.264)"),
+            new CodecPreferenceItem(CodecPreference.HevcOnly, "仅 HEVC (H.265)"),
+        };
+
+        // Quality levels in descending order
+        private static readonly int[] QualityLevels = { 30000, 20000, 10000, 400, 250, 150, 80 };
+
+        public static readonly QualityItem[] QualityItems = new[]
+        {
+            new QualityItem(30000, "杜比 (30000)"),
+            new QualityItem(20000, "4K (20000)"),
+            new QualityItem(10000, "原画 (10000)"),
+            new QualityItem(400, "蓝光 (400)"),
+            new QualityItem(250, "超清 (250)"),
+            new QualityItem(150, "高清 (150)"),
+            new QualityItem(80, "流畅 (80)"),
+        };
+
+        /// <summary>
+        /// Generate a RecordingQuality string from dropdown selections.
+        /// Includes all quality levels from the selected max downward for automatic fallback.
+        /// </summary>
+        public static string GenerateQualityString(CodecPreference codec, int maxQn)
+        {
+            var qualitiesFromMax = QualityLevels.Where(q => q <= maxQn).ToArray();
+            if (qualitiesFromMax.Length == 0)
+                qualitiesFromMax = new[] { maxQn };
+
+            var parts = new List<string>();
+
+            switch (codec)
+            {
+                case CodecPreference.AvcOnly:
+                    foreach (var q in qualitiesFromMax)
+                        parts.Add($"avc{q}");
+                    break;
+
+                case CodecPreference.HevcOnly:
+                    foreach (var q in qualitiesFromMax)
+                        parts.Add($"hevc{q}");
+                    break;
+
+                case CodecPreference.AvcFirst:
+                    foreach (var q in qualitiesFromMax)
+                    {
+                        parts.Add($"avc{q}");
+                        parts.Add($"hevc{q}");
+                    }
+                    break;
+
+                case CodecPreference.HevcFirst:
+                    foreach (var q in qualitiesFromMax)
+                    {
+                        parts.Add($"hevc{q}");
+                        parts.Add($"avc{q}");
+                    }
+                    break;
+            }
+
+            return string.Join(",", parts);
+        }
+
+        /// <summary>
+        /// Parse RecordingQuality string to determine codec preference and max quality.
+        /// Returns false if parsing cannot determine values (e.g., user entered custom string).
+        /// </summary>
+        public static bool TryParseQualityString(string? qualityString, out CodecPreference codec, out int maxQn)
+        {
+            codec = CodecPreference.AvcFirst;
+            maxQn = 10000;
+
+            if (string.IsNullOrWhiteSpace(qualityString))
+                return false;
+
+            var separators = new[] { ',', '，', '、', ' ' };
+            var entries = qualityString!.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            if (entries.Length == 0)
+                return false;
+
+            var parsed = new List<(bool isAvc, int qn)>();
+            foreach (var entry in entries)
+            {
+                var e = entry.Trim();
+                if (int.TryParse(e, out var num))
+                {
+                    parsed.Add((true, num));
+                }
+                else if (e.StartsWith("avc", StringComparison.OrdinalIgnoreCase) && int.TryParse(e.Substring(3), out num))
+                {
+                    parsed.Add((true, num));
+                }
+                else if (e.StartsWith("hevc", StringComparison.OrdinalIgnoreCase) && int.TryParse(e.Substring(4), out num))
+                {
+                    parsed.Add((false, num));
+                }
+                else
+                {
+                    // Unknown token, treat as custom string
+                    return false;
+                }
+            }
+
+            if (parsed.Count == 0 || parsed.Count != entries.Length)
+                return false;
+
+            // Determine max quality from first entry
+            maxQn = parsed[0].qn;
+
+            // Determine codec preference from patterns
+            var hasAvc = parsed.Any(p => p.isAvc);
+            var hasHevc = parsed.Any(p => !p.isAvc);
+
+            if (hasAvc && !hasHevc)
+            {
+                codec = CodecPreference.AvcOnly;
+            }
+            else if (!hasAvc && hasHevc)
+            {
+                codec = CodecPreference.HevcOnly;
+            }
+            else if (hasAvc && hasHevc)
+            {
+                // Check first entry to determine priority
+                codec = parsed[0].isAvc ? CodecPreference.AvcFirst : CodecPreference.HevcFirst;
+            }
+
+            // Validate that maxQn is a known quality level
+            if (!QualityLevels.Contains(maxQn))
+            {
+                // Find nearest known quality level that is <= maxQn (do not exceed requested max)
+                var currentMax = maxQn;
+                var nearest = QualityLevels.Where(q => q <= currentMax).FirstOrDefault();
+                if (nearest == 0)
+                    nearest = QualityLevels[QualityLevels.Length - 1]; // use lowest
+                maxQn = nearest;
+            }
+
+            return true;
+        }
+    }
+}

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -125,10 +125,28 @@
                             <ui:PathIcon Margin="5,0,0,0" Width="15" Height="15" Style="{StaticResource PathIconDataOpenInNew}"/>
                         </StackPanel>
                     </Button>
-                    <TextBlock Text="逗号分割的录制画质ID"/>
                     <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasRecordingQuality}">
-                        <TextBox Text="{Binding RecordingQuality,UpdateSourceTrigger=PropertyChanged,Delay=1000}"
-                                 ui:TextBoxHelper.IsDeleteButtonVisible="False" Width="220" HorizontalAlignment="Left"/>
+                        <StackPanel>
+                            <!-- 下拉选项模式 -->
+                            <StackPanel Loaded="QualityDropdownPanel_Loaded">
+                                <TextBlock Text="编码格式" Margin="0,2,0,2"/>
+                                <ComboBox Loaded="CodecComboBox_Loaded" Width="220" HorizontalAlignment="Left"
+                                          SelectionChanged="CodecOrQuality_SelectionChanged"/>
+                                <TextBlock Text="最高录制画质" Margin="0,8,0,2"/>
+                                <ComboBox Loaded="QualityComboBox_Loaded" Width="220" HorizontalAlignment="Left"
+                                          SelectionChanged="CodecOrQuality_SelectionChanged"/>
+                                <TextBlock Text="若直播源无所选画质，将自动降至最近可用画质" Margin="0,4,0,0"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" FontSize="12"/>
+                            </StackPanel>
+                            <!-- 高级手动模式 -->
+                            <StackPanel Loaded="QualityAdvancedPanel_Loaded" Visibility="Collapsed">
+                                <TextBlock Text="逗号分割的录制画质ID" Margin="0,2,0,2"/>
+                                <TextBox Text="{Binding RecordingQuality,UpdateSourceTrigger=PropertyChanged,Delay=1000}"
+                                         ui:TextBoxHelper.IsDeleteButtonVisible="False" Width="220" HorizontalAlignment="Left"/>
+                            </StackPanel>
+                            <CheckBox Content="高级选项（手动填入参数）" Margin="0,6,0,0"
+                                      Checked="QualityAdvancedModeCheckBox_Changed" Unchecked="QualityAdvancedModeCheckBox_Changed"/>
+                        </StackPanel>
                     </c:SettingWithDefault>
                 </StackPanel>
             </GroupBox>

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml.cs
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using BililiveRecorder.Core.Config.V3;
 using BililiveRecorder.Core.Templating;
+using BililiveRecorder.WPF.Models;
 using Newtonsoft.Json.Linq;
 using Serilog;
 
@@ -29,6 +31,11 @@ namespace BililiveRecorder.WPF.Pages
         };
 
         private readonly GlobalConfig? globalConfig;
+        private bool suppressQualityUpdate;
+        private System.Windows.Controls.ComboBox? codecComboBox;
+        private System.Windows.Controls.ComboBox? qualityComboBox;
+        private System.Windows.Controls.StackPanel? qualityDropdownPanel;
+        private System.Windows.Controls.StackPanel? qualityAdvancedPanel;
 
         public SettingsPage() : this((GlobalConfig?)(RootPage.ServiceProvider?.GetService(typeof(GlobalConfig))))
         {
@@ -39,6 +46,99 @@ namespace BililiveRecorder.WPF.Pages
             this.globalConfig = globalConfig;
 
             this.InitializeComponent();
+        }
+
+        private void CodecComboBox_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            this.codecComboBox = (System.Windows.Controls.ComboBox)sender;
+            this.codecComboBox.ItemsSource = RecordingQualityHelper.CodecPreferenceItems;
+            this.SyncDropdownsFromConfig();
+        }
+
+        private void QualityComboBox_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            this.qualityComboBox = (System.Windows.Controls.ComboBox)sender;
+            this.qualityComboBox.ItemsSource = RecordingQualityHelper.QualityItems;
+            this.SyncDropdownsFromConfig();
+        }
+
+        private void QualityDropdownPanel_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            this.qualityDropdownPanel = (System.Windows.Controls.StackPanel)sender;
+        }
+
+        private void QualityAdvancedPanel_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            this.qualityAdvancedPanel = (System.Windows.Controls.StackPanel)sender;
+        }
+
+        private void SyncDropdownsFromConfig()
+        {
+            if (this.codecComboBox is null || this.qualityComboBox is null)
+                return;
+
+            this.suppressQualityUpdate = true;
+            try
+            {
+                var qualityString = this.globalConfig?.RecordingQuality;
+
+                if (RecordingQualityHelper.TryParseQualityString(qualityString, out var codec, out var maxQn))
+                {
+                    this.codecComboBox.SelectedItem = RecordingQualityHelper.CodecPreferenceItems
+                        .FirstOrDefault(x => x.Value == codec)
+                        ?? RecordingQualityHelper.CodecPreferenceItems[0];
+
+                    this.qualityComboBox.SelectedItem = RecordingQualityHelper.QualityItems
+                        .FirstOrDefault(x => x.Qn == maxQn)
+                        ?? RecordingQualityHelper.QualityItems[2]; // default: 原画
+                }
+                else
+                {
+                    this.codecComboBox.SelectedIndex = 0;
+                    this.qualityComboBox.SelectedIndex = 2; // 原画
+                }
+            }
+            finally
+            {
+                this.suppressQualityUpdate = false;
+            }
+        }
+
+        private void CodecOrQuality_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (this.suppressQualityUpdate || this.globalConfig is null)
+                return;
+
+            if (this.codecComboBox?.SelectedItem is CodecPreferenceItem codecItem
+                && this.qualityComboBox?.SelectedItem is QualityItem qualityItem)
+            {
+                var qualityString = RecordingQualityHelper.GenerateQualityString(codecItem.Value, qualityItem.Qn);
+                this.globalConfig.RecordingQuality = qualityString;
+            }
+        }
+
+        private void QualityAdvancedModeCheckBox_Changed(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var checkBox = (System.Windows.Controls.CheckBox)sender;
+            var isAdvanced = checkBox.IsChecked == true;
+
+            if (!isAdvanced)
+            {
+                // Switching back to dropdown mode — try to parse current config
+                var qualityString = this.globalConfig?.RecordingQuality;
+                if (!RecordingQualityHelper.TryParseQualityString(qualityString, out _, out _))
+                {
+                    // Cannot parse custom string, stay in advanced mode
+                    checkBox.IsChecked = true;
+                    return;
+                }
+                this.SyncDropdownsFromConfig();
+            }
+
+            if (this.qualityDropdownPanel != null)
+                this.qualityDropdownPanel.Visibility = isAdvanced ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+            if (this.qualityAdvancedPanel != null)
+                this.qualityAdvancedPanel.Visibility = isAdvanced ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
         }
 
 #pragma warning disable VSTHRD100 // Avoid async void methods


### PR DESCRIPTION
## Summary / 改动说明

Replace the raw text input for recording quality with a reusable, binding-first editor control.

将录制画质的原始文本输入替换为一个可复用、以 Binding 为主的编辑控件。

### Current behavior / 当前行为

- The preset UI is a fixed one-way generator: codec preference + max quality -> `RecordingQuality` string.
- 预设 UI 是固定的单向生成器：编码偏好 + 最高画质 -> `RecordingQuality` 字符串。
- Advanced mode exposes the raw text value directly for manual editing.
- 高级模式直接暴露原始文本值，供手动编辑。
- There is no reverse string-to-dropdown parsing in the current design.
- 当前设计不再做字符串到下拉选项的反向解析。
- When custom recording quality is enabled but the current value is empty, the control normalizes it to the current preset value.
- 当启用自定义录制画质但当前值为空时，控件会将其归一化为当前预设值。
- The same control is reused by both global settings and per-room settings.
- 同一个控件同时复用于全局设置和单房间设置。

### Files / 相关文件

- `BililiveRecorder.WPF/Controls/RecordingQualityEditor.xaml`
- `BililiveRecorder.WPF/Controls/RecordingQualityEditor.xaml.cs`
- `BililiveRecorder.WPF/Models/RecordingQualityEditorLogic.cs`
- `BililiveRecorder.WPF/Models/RecordingQualityHelper.cs`
- `BililiveRecorder.WPF/Pages/SettingsPage.xaml`
- `BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml`
- `test/BililiveRecorder.Core.UnitTests/RecordingQualityEditorLogicTests.cs`
- `test/BililiveRecorder.Core.UnitTests/RecordingQualityHelperTests.cs`

### Notes / 说明

This version follows the maintainer feedback to keep the implementation binding-first and reusable, while avoiding lossy reverse parsing from custom strings back into preset dropdown state.

这一版按 maintainer 的反馈收敛为 binding-first、可复用的实现，同时避免将自定义字符串有损地反向解析回预设下拉状态。